### PR TITLE
Trail heirarchy

### DIFF
--- a/components/mapBox.js
+++ b/components/mapBox.js
@@ -17,7 +17,7 @@ export default class MapBox extends React.PureComponent {
       this.mapboxed.addSource(source.id, {
         data: source.data,
         type: "geojson",
-        tolerance: 0.5
+        tolerance: 0.3
       });
     }.bind(this));
 
@@ -98,7 +98,7 @@ export default class MapBox extends React.PureComponent {
     this.mapboxed = new MapboxGL.Map({
       container: 'mapbox-gl-element',
       style: styleUrl,
-      center: [-111 , 37.9],
+      center: [-110.37, 40.77],
       zoom: 8
     })
 

--- a/components/mapBox.js
+++ b/components/mapBox.js
@@ -17,7 +17,7 @@ export default class MapBox extends React.PureComponent {
       this.mapboxed.addSource(source.id, {
         data: source.data,
         type: "geojson",
-        tolerance: 0.05
+        tolerance: 0.5
       });
     }.bind(this));
 

--- a/migrations/1486669639681-createTrails.js
+++ b/migrations/1486669639681-createTrails.js
@@ -8,8 +8,9 @@ exports.up = function(next) {
       id SERIAL PRIMARY KEY,
       name VARCHAR(200),
       surface VARCHAR(64),
-      source_id varchar(50),
-      source varchar(200),
+      source_id VARCHAR(50),
+      source VARCHAR(200),
+      type VARCHAR(100),
       geog geography(GEOMETRY,4326)
     )`;
 

--- a/migrations/1486670803817-addUtahTrails.js
+++ b/migrations/1486670803817-addUtahTrails.js
@@ -29,6 +29,7 @@ exports.up = function(next) {
     name: 'primarynam',
     sourceId: 'trailid',
     geog: 'geog',
+    type: 'type',
     sourceUrl: 'https://gis.utah.gov/data/recreation/trails/',
   }, next);
 };

--- a/migrations/1486670803817-addUtahTrails.js
+++ b/migrations/1486670803817-addUtahTrails.js
@@ -10,6 +10,19 @@ exports.up = function(next) {
     srid: '26912'
   });
 
+  utils.genericQuery(`
+    ALTER TABLE utah_trails ADD type text;
+    UPDATE utah_trails SET
+      type = CASE
+      WHEN designated like '%4WD%' THEN 'road'
+      WHEN designated like '%ATV%' THEN 'atv'
+      WHEN designated like '%MOTORCYCLE%' THEN 'motorcycle'
+      WHEN designated like '%BIKE%' THEN 'bike'
+      WHEN designated like '%HORSE%' THEN 'horse'
+      WHEN designated like '%HIKE%' THEN 'hike'
+      END;
+  `)
+
   utils.mergeIntoTrailsTable({
     baseTableName: 'trails',
     mergingTableName: 'utah_trails',

--- a/migrations/1486670870460-addWashingtonTrails.js
+++ b/migrations/1486670870460-addWashingtonTrails.js
@@ -10,12 +10,29 @@ exports.up = function(next) {
     srid: "2927"
   });
 
+  utils.genericQuery(`
+    ALTER TABLE washington_trails ADD type text;
+    UPDATE washington_trails SET
+      type = CASE
+      WHEN four_wheel = 'Yes' then 'road'
+      WHEN atv = 'Yes' THEN 'atv'
+      WHEN motorcycle = 'Yes' THEN 'motorcycle'
+      WHEN bicycle = 'Yes' THEN 'bike'
+      WHEN pack_and_s = 'Yes' THEN 'horse'
+      WHEN hiker_pede = 'Yes' THEN 'hike'
+      WHEN snowshoe = 'Yes' THEN 'snow'
+      WHEN cross_coun = 'Yes' THEN 'snow'
+      WHEN snowmobile = 'Yes' THEN 'snow'
+      END;
+  `)
+
   utils.mergeIntoTrailsTable({
     baseTableName: 'trails',
     mergingTableName: 'washington_trails',
     name: 'tr_nm',
     sourceId: 'globalid',
     geog: 'geog',
+    type: 'type',
     sourceUrl: 'http://www.rco.wa.gov/maps/Data.shtml',
   }, next);
 };

--- a/migrations/1486678630915-insertElevationRasters.js
+++ b/migrations/1486678630915-insertElevationRasters.js
@@ -7,9 +7,7 @@ exports.up = function(next) {
     directoryName: 'elevation_rasters',
     srid: '4326',
     tableName: 'elevation'
-  });
-
-  next();
+  }, next);
 };
 
 exports.down = function(next) {

--- a/migrations/1488747571006-addNationalMotorVehicleUseMapTrails.js
+++ b/migrations/1488747571006-addNationalMotorVehicleUseMapTrails.js
@@ -10,12 +10,23 @@ exports.up = function(next) {
     srid: '4269'
   });
 
+  utils.genericQuery(`
+    ALTER TABLE national_mvum_trails ADD type text;
+    UPDATE national_mvum_trails SET
+      type = CASE
+      WHEN fourwd_gt5 = 'open' then 'road'
+      WHEN atv = 'open' THEN 'atv'
+      WHEN motorcycle = 'open' THEN 'motorcycle'
+      END;
+  `)
+
   utils.mergeIntoTrailsTable({
     baseTableName: 'trails',
     mergingTableName: 'national_mvum_trails',
     name: 'name',
     sourceId: 'id',
     geog: 'geog',
+    type: 'type',
     sourceUrl: 'https://data.fs.usda.gov/geodata/edw/edw_resources/meta/S_USA.Road_MVUM.xml',
   }, next);
 };

--- a/migrations/1488749216921-addNationalForestServiceTrails.js
+++ b/migrations/1488749216921-addNationalForestServiceTrails.js
@@ -10,12 +10,27 @@ exports.up = function(next) {
     srid: '4269'
   });
 
+  utils.genericQuery(`
+    ALTER TABLE national_forest_service_trails ADD type text;
+    UPDATE national_forest_service_trails SET
+      type = CASE
+      WHEN allowed_te like '%6%' then 'road'
+      WHEN allowed_te like '%5%' THEN 'atv'
+      WHEN allowed_te like '%4%' THEN 'motorcycle'
+      WHEN allowed_te like '%3%' THEN 'bike'
+      WHEN allowed_te like '%2%' THEN 'horse'
+      WHEN allowed_te like '%1%' THEN 'hike'
+      WHEN allowed_sn like 'N/A' THEN 'snow'
+      END;
+  `)
+
   utils.mergeIntoTrailsTable({
     baseTableName: 'trails',
     mergingTableName: 'national_forest_service_trails',
     name: 'trail_name',
     sourceId: 'trail_cn',
     geog: 'geog',
+    type: 'type',
     sourceUrl: 'https://data.fs.usda.gov/geodata/edw/edw_resources/meta/S_USA.TrailNFS_Publish.xml',
   }, next);
 };

--- a/migrations/1491942219315-addBitterrootTrails.js
+++ b/migrations/1491942219315-addBitterrootTrails.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const utils = require('./migrationUtils');
+
+exports.up = function(next) {
+  console.log("uploading bitterroot...")
+
+  utils.uploadShapeFile({
+    tableName: 'bitterroot',
+    directoryName: 'idaho_trails',
+    filename: 'bitterroot',
+    srid: '26911'
+  });
+
+  utils.genericQuery(`
+    ALTER TABLE bitterroot ADD type text;
+    UPDATE bitterroot SET
+      type = CASE
+      WHEN designed_u like '%ATV%' THEN 'atv'
+      WHEN designed_u like '%MTRCYCL%' THEN 'motorcycle'
+      WHEN designed_u like '%PACK%' THEN 'horse'
+      WHEN designed_u like '%HIKE%' THEN 'hike'
+      END;
+    ALTER TABLE bitterroot ADD geog2d geography;
+    UPDATE bitterroot SET geog2d = ST_Force2D(geog::geometry);
+  `)
+
+  utils.mergeIntoTrailsTable({
+    baseTableName: 'trails',
+    mergingTableName: 'bitterroot',
+    name: 'name',
+    sourceId: 'id',
+    geog: 'geog2d',
+    type: 'type',
+    sourceUrl: 'https://www.fs.usda.gov/detailfull/bitterroot/landmanagement/gis/?cid=fseprd523955&width=full',
+  }, next);
+};
+
+exports.down = function(next) {
+  utils.genericQuery("DELETE FROM trails WHERE source = 'https://www.fs.usda.gov/detailfull/bitterroot/landmanagement/gis/?cid=fseprd523955&width=full'", next);
+};

--- a/migrations/1491942232620-addNezPerceTrails.js
+++ b/migrations/1491942232620-addNezPerceTrails.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const utils = require('./migrationUtils');
+
+exports.up = function(next) {
+  console.log("uploading nez perce...")
+  //no type for this source. periodically check for updates here
+
+  utils.uploadShapeFile({
+    tableName: 'nez_perce',
+    directoryName: 'idaho_trails',
+    filename: 'TrailNez_20120328',
+    srid: '26911'
+  });
+
+  utils.genericQuery(`
+    ALTER TABLE nez_perce ADD type text;
+    UPDATE nez_perce SET type = 'mixed';
+    ALTER TABLE nez_perce ADD geog2d geography;
+    UPDATE nez_perce SET geog2d = ST_Force2D(geog::geometry);
+  `)
+
+  utils.mergeIntoTrailsTable({
+    baseTableName: 'trails',
+    mergingTableName: 'nez_perce',
+    name: 'name',
+    sourceId: 'rte_cn',
+    geog: 'geog2d',
+    type: 'type',
+    sourceUrl: 'https://www.fs.usda.gov/main/nezperceclearwater/landmanagement/gis#nezperce',
+  }, next);
+};
+
+exports.down = function(next) {
+  utils.genericQuery("DELETE FROM trails WHERE source = 'https://www.fs.usda.gov/detailfull/bitterroot/landmanagement/gis/?cid=fseprd523955&width=full'", next);
+};

--- a/migrations/1491942243934-addClearwaterTrails.js
+++ b/migrations/1491942243934-addClearwaterTrails.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const utils = require('./migrationUtils');
+
+exports.up = function(next) {
+  console.log("uploading clearwater...");
+  //no type for this source. periodically check for updates here
+
+  utils.uploadShapeFile({
+    tableName: 'clearwater',
+    directoryName: 'idaho_trails',
+    filename: 'TrailClw_20120328',
+    srid: '26911'
+  });
+
+  utils.genericQuery(`
+    ALTER TABLE clearwater ADD type text;
+    UPDATE clearwater SET type = 'mixed';
+    ALTER TABLE clearwater ADD geog2d geography;
+    UPDATE clearwater SET geog2d = ST_Force2D(geog::geometry);
+  `)
+
+  utils.mergeIntoTrailsTable({
+    baseTableName: 'trails',
+    mergingTableName: 'clearwater',
+    name: 'name',
+    sourceId: 'rte_cn',
+    geog: 'geog2d',
+    type: 'type',
+    sourceUrl: 'https://www.fs.usda.gov/main/nezperceclearwater/landmanagement/gis#clearwater',
+  }, next);
+};
+
+exports.down = function(next) {
+  utils.genericQuery("DELETE FROM trails WHERE source = 'https://www.fs.usda.gov/main/nezperceclearwater/landmanagement/gis#clearwater'", next);
+};

--- a/migrations/1491942255858-addSawtoothTrails.js
+++ b/migrations/1491942255858-addSawtoothTrails.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const utils = require('./migrationUtils');
+
+exports.up = function(next) {
+  console.log("uploading sawtooth...");
+  //warning: still using kml data. we should replace this some day
+
+  utils.uploadShapeFile({
+    tableName: 'sawtooth',
+    directoryName: 'idaho_trails',
+    filename: 'sawtooth-nf',
+    srid: '4326'
+  });
+
+  utils.genericQuery(`
+    ALTER TABLE sawtooth ADD type text;
+    UPDATE sawtooth SET type = 'trail';
+  `)
+
+  utils.mergeIntoTrailsTable({
+    baseTableName: 'trails',
+    mergingTableName: 'sawtooth',
+    name: 'name',
+    sourceId: 'sourceId',
+    geog: 'geog',
+    type: 'type',
+    sourceUrl: 'http://data.gis.idaho.gov/datasets?q=trails#sawtooth',
+  }, next);
+};
+
+exports.down = function(next) {
+  utils.genericQuery("DELETE FROM trails WHERE source = 'http://data.gis.idaho.gov/datasets?q=trails#sawtooth'", next);
+};

--- a/migrations/1491942255858-addSawtoothTrails.js
+++ b/migrations/1491942255858-addSawtoothTrails.js
@@ -15,7 +15,7 @@ exports.up = function(next) {
 
   utils.genericQuery(`
     ALTER TABLE sawtooth ADD type text;
-    UPDATE sawtooth SET type = 'trail';
+    UPDATE sawtooth SET type = 'hike';
   `)
 
   utils.mergeIntoTrailsTable({

--- a/migrations/1491942265835-addCaribouTargheeTrails.js
+++ b/migrations/1491942265835-addCaribouTargheeTrails.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const utils = require('./migrationUtils');
+
+exports.up = function(next) {
+  console.log("uploading caribou-targhee...");
+  //warning: still using kml data. we should replace this some day
+
+  utils.uploadShapeFile({
+    tableName: 'caribou_targhee',
+    directoryName: 'idaho_trails',
+    filename: 'caribou-targhee',
+    srid: '4326'
+  });
+
+  utils.genericQuery(`
+    ALTER TABLE caribou_targhee ADD type text;
+    UPDATE caribou_targhee SET type = 'mixed';
+  `)
+
+  utils.mergeIntoTrailsTable({
+    baseTableName: 'trails',
+    mergingTableName: 'caribou_targhee',
+    name: 'name',
+    sourceId: 'sourceId',
+    geog: 'geog',
+    type: 'type',
+    sourceUrl: 'http://data.gis.idaho.gov/datasets?q=trails#caribou-targhee',
+  }, next);
+};
+
+exports.down = function(next) {
+  utils.genericQuery("DELETE FROM trails WHERE source = 'http://data.gis.idaho.gov/datasets?q=trails#caribou-targhee'", next);
+};

--- a/migrations/migrationUtils.js
+++ b/migrations/migrationUtils.js
@@ -52,7 +52,21 @@ exports.mergeIntoTrailsTable = function({baseTableName, mergingTableName, name =
     CREATE TABLE ${baseTableName}__new AS SELECT * FROM ${baseTableName};
 
     INSERT INTO ${baseTableName}__new(name, source_id, geog, type, source)
-    SELECT ${name}, ${sourceId}, ${geog}, ${type}, '${sourceUrl}' FROM ${mergingTableName};
+    SELECT
+      simple.${name},
+      simple.${sourceId},
+      simple.simple_geom,
+      simple.${type},
+      '${sourceUrl}'
+    FROM (
+      SELECT
+        dumped.*,
+        (dumped.geom_dump).geom as simple_geom,
+        (dumped.geom_dump).path as path
+      FROM (
+        SELECT *, ST_Dump(${geog}::geometry) AS geom_dump FROM ${mergingTableName}
+      ) AS dumped
+    ) AS simple;
 
     DROP TABLE ${baseTableName};
 

--- a/modules/convertKmlAttribues.js
+++ b/modules/convertKmlAttribues.js
@@ -1,6 +1,3 @@
-'use strict'
-
-const utils = require('./migrationUtils');
 const xml2js = require('xml2js');
 const fs = require('fs');
 const path = require('path').normalize;
@@ -9,35 +6,7 @@ const env = require('../environment/development');
 const directoryName = "idaho_trails"
 const workingDir = path(env.libDirectory + "/" + directoryName);
 
-exports.up = function(next) {
-  convertCrazyKmlAttributes();
-
-  if (!fs.existsSync(path(workingDir + "/idaho-nonmotorized.shp"))) {
-    execSync(`ogr2ogr -nlt LINESTRING -skipfailures idaho-nonmotorized.shp idaho-nonmotorized-converted.geojson`, {cwd: workingDir});
-  };
-
-  utils.uploadShapeFile({
-    tableName: 'idaho_trails',
-    directoryName: 'idaho_trails',
-    filename: 'idaho-nonmotorized',
-    srid: '4326'
-  });
-
-  utils.mergeIntoTrailsTable({
-    baseTableName: 'trails',
-    mergingTableName: 'idaho_trails',
-    name: 'name',
-    sourceId: 'sourceId',
-    geog: 'geog',
-    sourceUrl: 'http://data.gis.idaho.gov/datasets?q=trails',
-  }, next);
-};
-
-exports.down = function(next) {
-  utils.genericQuery("DELETE FROM trails WHERE source = 'http://data.gis.idaho.gov/datasets?q=trails'", next);
-};
-
-const convertCrazyKmlAttributes = function() {
+export const convertCrazyKmlAttributes = function() {
   const readPath = path(env.libDirectory + "/" + directoryName + "/idaho-nonmotorized.geojson");
   const writePath = path(env.libDirectory + "/" + directoryName + "/idaho-nonmotorized-converted.geojson");
 

--- a/modules/mapBoxLayers.js
+++ b/modules/mapBoxLayers.js
@@ -9,6 +9,7 @@ export const mapBoxLayers = [
       "circle-color": "#FF9100"
     }
   },
+
   {
     'id': 'handles-outline',
     'source': 'handles',
@@ -19,6 +20,7 @@ export const mapBoxLayers = [
       "circle-color": "#FFF"
     }
   },
+
   {
     'id': 'handles',
     'source': 'handles',
@@ -28,6 +30,7 @@ export const mapBoxLayers = [
       "circle-color": "rgba(0,0,0,0)"
     }
   },
+
   {
     'id': 'trails',
     'source': 'trails',
@@ -35,8 +38,75 @@ export const mapBoxLayers = [
     'paint': {
       'line-color': 'transparent',
       'line-width': 15
-    }
+    },
+    "filter": ["!=", "type", "unknown"]
   },
+
+  {
+    'id': 'trails-core-line',
+    'source': 'trails',
+    'type': 'line',
+    'before': 'hedges',
+    'line': {
+      'line-cap': 'round',
+      'line-join': 'bevel'
+    },
+    'paint': {
+      'line-color': 'rgba(0,155,1,1)',
+      'line-width': 2
+    },
+    "filter": ["in", "type", "hike"]
+  },
+
+  {
+    'id': 'horse-and-bike-core-line',
+    'source': 'trails',
+    'type': 'line',
+    'before': 'hedges',
+    'line': {
+      'line-cap': 'round',
+      'line-join': 'bevel'
+    },
+    'paint': {
+      'line-color': 'rgba(120,125,120,1)',
+      'line-width': 2
+    },
+    "filter": ["in", "type", "horse", "bike"]
+  },
+
+  {
+    'id': 'trails-outline',
+    'source': 'trails',
+    'type': 'line',
+    'before': 'trails-core-line',
+    'line': {
+      'line-cap': 'round',
+      'line-join': 'bevel'
+    },
+    'paint': {
+      'line-color': 'rgba(250,250,250,1)',
+      'line-width': 4
+    },
+    "filter": ["in", "type", "hike", "horse", "bike"]
+  },
+
+  {
+    'id': 'atv-and-motorcycle-core-line',
+    'source': 'trails',
+    'type': 'line',
+    'before': 'roads',
+    'line': {
+      'line-cap': 'round',
+      'line-join': 'bevel'
+    },
+    'paint': {
+      'line-color': 'rgba(100,100,100,1)',
+      'line-width': 1,
+      'line-dasharray': 5
+    },
+    "filter": ["in", "type", "atv", "motorcycle", "mixed"]
+  },
+
   {
     'id': 'trails-active',
     'source': 'trails-active',
@@ -47,27 +117,7 @@ export const mapBoxLayers = [
       'line-width': 2,
     }
   },
-  {
-    'id': 'trails-core-line',
-    'source': 'trails',
-    'type': 'line',
-    'before': 'water',
-    'paint': {
-      'line-color': '#0DB224',
-      'line-width': 2
-    }
-  },
-  {
-    'id': 'trails-outline',
-    'source': 'trails',
-    'type': 'line',
-    'before': 'trails-core-line',
-    'paint': {
-      'line-color': '#fff',
-      'line-width': 4,
-      'line-opacity': 0.3
-    }
-  },
+
   {
     'id': 'boundaries-active-outline',
     'source': 'boundaries-active',
@@ -82,6 +132,7 @@ export const mapBoxLayers = [
       'line-opacity': 0.9
     }
   },
+
   {
     'id': 'boundaries-active',
     'source': 'boundaries-active',
@@ -92,6 +143,7 @@ export const mapBoxLayers = [
       'fill-opacity': 0.2
     }
   },
+
   {
     'id': 'boundaries',
     'source': 'boundaries',
@@ -100,5 +152,5 @@ export const mapBoxLayers = [
     'paint': {
       'fill-color': 'rgba(0, 0, 0, 0%)'
     }
-  },
+  }
 ]

--- a/modules/mapBoxLayers.js
+++ b/modules/mapBoxLayers.js
@@ -39,7 +39,7 @@ export const mapBoxLayers = [
       'line-color': 'transparent',
       'line-width': 15
     },
-    "filter": ["!=", "type", "unknown"]
+    "filter": ["all", ["in", "type", "hike", "horse", "bike", "atv", "motorcycle", "trail"]]
   },
 
   {
@@ -52,14 +52,15 @@ export const mapBoxLayers = [
       'line-join': 'bevel'
     },
     'paint': {
-      'line-color': 'rgba(0,155,1,1)',
-      'line-width': 2,
+      'line-color': 'rgba(0,123,14,1)',
+      'line-width': 1,
+      'line-dasharray': [4, 1]
     },
-    "filter": ["in", "type", "hike"]
+    "filter": ["all", ["in", "type", "hike", "trail"], ["!=", "name", ""]]
   },
 
   {
-    'id': 'horse-and-bike-core-line',
+    'id': 'horse-core-line',
     'source': 'trails',
     'type': 'line',
     'before': 'hedges',
@@ -68,10 +69,11 @@ export const mapBoxLayers = [
       'line-join': 'bevel'
     },
     'paint': {
-      'line-color': 'rgba(120,125,120,1)',
-      'line-width': 2,
+      'line-color': 'rgba(160,115,120,1)',
+      'line-width': 1,
+      'line-dasharray': [4, 1]
     },
-    "filter": ["in", "type", "horse", "bike"]
+    "filter": ["all", ["in", "type", "horse"], ["!=", "name", ""]]
   },
 
   {
@@ -85,9 +87,9 @@ export const mapBoxLayers = [
     },
     'paint': {
       'line-color': 'rgba(250,250,250,1)',
-      'line-width': 4
+      'line-width': 3
     },
-    "filter": ["in", "type", "hike", "horse", "bike"]
+    "filter": ["all", ["in", "type", "hike", "horse", "trail"], ["!=", "name", ""]]
   },
 
   {
@@ -100,11 +102,11 @@ export const mapBoxLayers = [
       'line-join': 'bevel'
     },
     'paint': {
-      'line-color': 'rgba(150,150,150,1)',
+      'line-color': 'rgba(180,180,180,1)',
       'line-width': 1,
       'line-dasharray': [2, 1]
     },
-    "filter": ["in", "type", "atv", "motorcycle", "mixed"]
+    "filter": ["any", ["in", "type", "bike", "atv", "motorcycle", "mixed"], ["==", "name", ""]]
   },
 
   {

--- a/modules/mapBoxLayers.js
+++ b/modules/mapBoxLayers.js
@@ -53,7 +53,7 @@ export const mapBoxLayers = [
     },
     'paint': {
       'line-color': 'rgba(0,155,1,1)',
-      'line-width': 2
+      'line-width': 2,
     },
     "filter": ["in", "type", "hike"]
   },
@@ -69,7 +69,7 @@ export const mapBoxLayers = [
     },
     'paint': {
       'line-color': 'rgba(120,125,120,1)',
-      'line-width': 2
+      'line-width': 2,
     },
     "filter": ["in", "type", "horse", "bike"]
   },
@@ -100,9 +100,9 @@ export const mapBoxLayers = [
       'line-join': 'bevel'
     },
     'paint': {
-      'line-color': 'rgba(100,100,100,1)',
+      'line-color': 'rgba(150,150,150,1)',
       'line-width': 1,
-      'line-dasharray': 5
+      'line-dasharray': [2, 1]
     },
     "filter": ["in", "type", "atv", "motorcycle", "mixed"]
   },

--- a/modules/mapBoxLayers.js
+++ b/modules/mapBoxLayers.js
@@ -24,7 +24,7 @@ export const mapBoxLayers = [
     'source': 'handles',
     'type': 'circle',
     'paint': {
-      "circle-radius": 10,
+      "circle-radius": 8,
       "circle-color": "rgba(0,0,0,0)"
     }
   },

--- a/modules/mapboxStaticData.js
+++ b/modules/mapboxStaticData.js
@@ -1,2 +1,2 @@
 export const accessToken = 'pk.eyJ1IjoiZml2ZWZvdXJ0aHMiLCJhIjoiY2lvMXM5MG45MWFhenUybTNkYzB1bzJ0MiJ9._5Rx_YN9mGwR8dwEB9D2mg';
-export const styleUrl = 'mapbox://styles/fivefourths/cizrqzobe00202spk9fqzigdf'
+export const styleUrl = 'mapbox://styles/fivefourths/cj1fdtp1f00002sttxerc303x'

--- a/server.js
+++ b/server.js
@@ -34,6 +34,7 @@ app.get('/api/trails/:x1/:y1/:x2/:y2', function(request, response) {
     SELECT
       name,
       id,
+      type,
       ST_AsGeoJson(geog) as geog
     FROM trails
     WHERE ST_Intersects(geog,
@@ -53,6 +54,7 @@ app.get('/api/trails/:x1/:y1/:x2/:y2', function(request, response) {
           "properties": {
             "name": r.name,
             "id": r.id,
+            "type": r.type
           },
           "geometry": JSON.parse(r.geog)
         };

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ app.get('/api/trails/:x1/:y1/:x2/:y2', function(request, response) {
     SELECT
       name,
       id,
-      ST_AsGeoJson(ST_LineMerge(geog::geometry)) as geog
+      ST_AsGeoJson(geog) as geog
     FROM trails
     WHERE ST_Intersects(geog,
       ST_MakeEnvelope(${request.params.x1}, ${request.params.y1}, ${request.params.x2}, ${request.params.y2})


### PR DESCRIPTION
this pull cleans up the trails data. it:

1. adds a 'type' field so we can start to build a visual heirarchy
2. ensures that all trails are linestrings
3. adds styles to help differentiate between bike, hike, horse, & atv trails
4. uses actual NF data for idaho trails, and polyfills the two missing forests (sawtooth & C-T) with kml data